### PR TITLE
chore: fix repo bot action runtime

### DIFF
--- a/.github/workflows/repo-bot.yml
+++ b/.github/workflows/repo-bot.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Repo Bot
-        uses: ddaodan/bettergi-github-bot@028ebdeda1fd95263429f0bba37be08402752170
+        uses: ddaodan/bettergi-github-bot@0ebb41b8907660681784165bdc12d183765dc47d
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REPO_BOT_AI_API_KEY: ${{ secrets.REPO_BOT_AI_API_KEY }}


### PR DESCRIPTION
## Summary
- update the repo bot action pin to the fixed central commit
- pick up the bundled CommonJS action entry so GitHub Actions can execute it without missing runtime packages

## Verification
- central action: lint/test/build passed
- bundled entry changed to dist/index.cjs and no longer depends on runner-installed node_modules