### PR TITLE
chore: update repo bot action pin

### DIFF
--- a/.github/workflows/repo-bot.yml
+++ b/.github/workflows/repo-bot.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Repo Bot
-        uses: ddaodan/bettergi-github-bot@0ebb41b8907660681784165bdc12d183765dc47d
+        uses: ddaodan/bettergi-github-bot@ab2ff0e2acbf8003ac5c88bd6b8977a25075509d
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REPO_BOT_AI_API_KEY: ${{ secrets.REPO_BOT_AI_API_KEY }}


### PR DESCRIPTION
## Summary
- update the repo bot action pin to the latest central fix
- pick up the AI base URL fallback that retries with /v1 when the configured base URL uses the service root