### PR TITLE
chore: update repo bot action pin

### DIFF
--- a/.github/workflows/repo-bot.yml
+++ b/.github/workflows/repo-bot.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Repo Bot
-        uses: ddaodan/bettergi-github-bot@ab2ff0e2acbf8003ac5c88bd6b8977a25075509d
+        uses: ddaodan/bettergi-github-bot@188487b3a0df9ab83e9e7125d1bf78a28ee2563b
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REPO_BOT_AI_API_KEY: ${{ secrets.REPO_BOT_AI_API_KEY }}


### PR DESCRIPTION
## Summary
- update the repo bot action pin to the workflow-safe AI fallback fix
- keep issue automation green even when the configured AI key is rejected upstream