### PR TITLE
chore: switch repo bot model to gpt-5.4

### DIFF
--- a/.github/repo-bot.yml
+++ b/.github/repo-bot.yml
@@ -6,7 +6,7 @@ providers:
   openAiCompatible:
     enabled: true
     baseUrl: https://api.openai.com/v1
-    model: gpt-5-mini
+    model: gpt-5.4
     apiStyle: responses
     timeoutMs: 30000
 


### PR DESCRIPTION
## Summary
- switch the repo bot AI model from gpt-5-mini to gpt-5.4
- keep the rest of the repo bot integration unchanged