### PR TITLE
chore: add repo bot project context

### DIFF
--- a/.github/repo-bot.yml
+++ b/.github/repo-bot.yml
@@ -151,6 +151,21 @@ issues:
     enabled: true
     triggerLabels: []
     commentAnchor: issue-bot:ai
+    projectContext:
+      enabled: true
+      includeRepositoryMetadata: true
+      includeReadme: true
+      readmeMaxChars: 3000
+      profile:
+        name: BetterGI
+        aliases:
+          - BGI
+          - Better Genshin Impact
+        summary: BetterGI is a desktop automation assistant for Genshin Impact.
+        techStack:
+          - C#
+          - WPF
+          - .NET
 
 pullRequests:
   review:

--- a/.github/workflows/repo-bot.yml
+++ b/.github/workflows/repo-bot.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Repo Bot
-        uses: ddaodan/bettergi-github-bot@943f44961fa90b85b389b00bf3aa7f8966d54920
+        uses: ddaodan/bettergi-github-bot@78d8cee0c16bc7871ad28658c71952a3d6b9f77e
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REPO_BOT_AI_API_KEY: ${{ secrets.REPO_BOT_AI_API_KEY }}


### PR DESCRIPTION
## Summary
- update the repo bot action pin to the AI project-context build
- add issue AI project context profile for BetterGI
- keep README and repository metadata context enabled for AI help

## Testing
- not run (workflow/config only)