### PR TITLE
chore: update repo bot action pin

### DIFF
--- a/.github/workflows/repo-bot.yml
+++ b/.github/workflows/repo-bot.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Repo Bot
-        uses: ddaodan/bettergi-github-bot@78d8cee0c16bc7871ad28658c71952a3d6b9f77e
+        uses: ddaodan/bettergi-github-bot@b814f14a1b1a9989b53ba6429787e2fb96b420ac
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REPO_BOT_AI_API_KEY: ${{ secrets.REPO_BOT_AI_API_KEY }}


### PR DESCRIPTION
## Summary
- update the repo bot action pin to the validation-comment behavior change

## Testing
- not run (workflow pin only)