### PR TITLE
chore: update repo bot action pin

### DIFF
--- a/.github/workflows/repo-bot.yml
+++ b/.github/workflows/repo-bot.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Repo Bot
-        uses: ddaodan/bettergi-github-bot@b814f14a1b1a9989b53ba6429787e2fb96b420ac
+        uses: ddaodan/bettergi-github-bot@c1ed9a96a2f8c80cfbac406cea99ec148d99833e
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REPO_BOT_AI_API_KEY: ${{ secrets.REPO_BOT_AI_API_KEY }}


### PR DESCRIPTION
## Summary
- update the repo bot action pin to the validation comment cleanup build

## Testing
- not run (workflow pin only)